### PR TITLE
Update CDU config and metrics

### DIFF
--- a/exporter_config.yaml
+++ b/exporter_config.yaml
@@ -67,4 +67,6 @@ psus:
   - name: 'Powershelf_1'
     apiUrl: 'https://192.168.2.50/redfish/v1/Chassis/chassis/Sensors/chassis_output_power'
 
-cdu_url: "http://192.168.2.201:1880/getall"
+cdu:
+  - name: 'cdu1'
+    url: "http://192.168.2.201:1880/getall"


### PR DESCRIPTION
## Summary
- support CDU configuration as list with name/url
- capture leakage metrics from CDU

## Testing
- `python3 -m py_compile exporter_main.py`

------
https://chatgpt.com/codex/tasks/task_e_6886e6f4028c8321afe85fafd510785a