### PR TITLE
Handle single CDU leakage sensor with keep_watching metrics

### DIFF
--- a/exporter_main.py
+++ b/exporter_main.py
@@ -265,9 +265,25 @@ def fetch_cdu_data():
                     cdu_leakage.labels(sensor_name=sensor_name, rack_name=rack_name).set(
                         0 if value is None else value
                     )
+                for sensor_name in leakage_values:
+                    cdu_leakage.labels(
+                        sensor_name=sensor_name,
+                        rack_name=f"keep_watching_{rack_name}",
+                    ).set(0)
+            elif leak_count == 1:
+                for sensor_name, value in leakage_values.items():
+                    cdu_leakage.labels(sensor_name=sensor_name, rack_name=rack_name).set(0)
+                    cdu_leakage.labels(
+                        sensor_name=sensor_name,
+                        rack_name=f"keep_watching_{rack_name}",
+                    ).set(0 if value is None else value)
             else:
                 for sensor_name in leakage_values:
                     cdu_leakage.labels(sensor_name=sensor_name, rack_name=rack_name).set(0)
+                    cdu_leakage.labels(
+                        sensor_name=sensor_name,
+                        rack_name=f"keep_watching_{rack_name}",
+                    ).set(0)
 
             # Calculate additional metrics if all required values are available
             if all(v is not None for v in (t_wi, t_wo)) and total_psu_power:


### PR DESCRIPTION
## Summary
- Expand CDU leakage handling to expose `keep_watching_` metrics when a single sensor triggers
- Clear `keep_watching_` metrics when multiple or no sensors trigger to avoid stale gauges

## Testing
- `python -m py_compile exporter_main.py`
- `python - <<'PY'
leakage_values = {"Sensor_L1":1,"Sensor_L2":0,"Sensor_RL1":0,"Sensor_RL2":0}
rack_name = "rackA"
leak_count=sum(1 for v in leakage_values.values() if v==1)
results={}
if leak_count >=2:
    for sensor_name, value in leakage_values.items():
        results[(sensor_name,rack_name)] = 0 if value is None else value
    for sensor_name in leakage_values:
        results[(sensor_name,f"keep_watching_{rack_name}")] = 0
elif leak_count==1:
    for sensor_name, value in leakage_values.items():
        results[(sensor_name,rack_name)] = 0
        results[(sensor_name,f"keep_watching_{rack_name}")] = 0 if value is None else value
else:
    for sensor_name in leakage_values:
        results[(sensor_name,rack_name)] = 0
        results[(sensor_name,f"keep_watching_{rack_name}")] = 0
print('Scenario one leak', results)

# Another scenario with two leaks
leakage_values = {"Sensor_L1":1,"Sensor_L2":1,"Sensor_RL1":0,"Sensor_RL2":0}
leak_count=sum(1 for v in leakage_values.values() if v==1)
results={}
if leak_count >=2:
    for sensor_name, value in leakage_values.items():
        results[(sensor_name,rack_name)] = 0 if value is None else value
    for sensor_name in leakage_values:
        results[(sensor_name,f"keep_watching_{rack_name}")] = 0
elif leak_count==1:
    for sensor_name, value in leakage_values.items():
        results[(sensor_name,rack_name)] = 0
        results[(sensor_name,f"keep_watching_{rack_name}")] = 0 if value is None else value
else:
    for sensor_name in leakage_values:
        results[(sensor_name,rack_name)] = 0
        results[(sensor_name,f"keep_watching_{rack_name}")] = 0
print('Scenario two leaks', results)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a533874a208321b2f569b928821a0c