### PR TITLE
Ensure CDU leakage resets keep_watching metrics

### DIFF
--- a/exporter_main.py
+++ b/exporter_main.py
@@ -265,6 +265,10 @@ def fetch_cdu_data():
                     cdu_leakage.labels(sensor_name=sensor_name, rack_name=rack_name).set(
                         0 if value is None else value
                     )
+                    cdu_leakage.labels(
+                        sensor_name=sensor_name,
+                        rack_name=f"keep_watching_{rack_name}",
+                    ).set(0)
             else:
                 for sensor_name in leakage_values:
                     cdu_leakage.labels(sensor_name=sensor_name, rack_name=rack_name).set(0)


### PR DESCRIPTION
## Summary
- Combine CDU leakage loops to set actual and `keep_watching_` metrics in one pass
- Reset `keep_watching_` metrics to zero whenever two or more leaks are detected

## Testing
- `python -m py_compile exporter_main.py`
- `timeout 5 python exporter_main.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests prometheus_client pyyaml` *(fails: Could not find a version that satisfies the requirement requests)*


------
https://chatgpt.com/codex/tasks/task_e_68a538bf7bb08321b2e48d726af9c880