### PR TITLE
Refactor leakage metric loops

### DIFF
--- a/exporter_main.py
+++ b/exporter_main.py
@@ -265,7 +265,6 @@ def fetch_cdu_data():
                     cdu_leakage.labels(sensor_name=sensor_name, rack_name=rack_name).set(
                         0 if value is None else value
                     )
-                for sensor_name in leakage_values:
                     cdu_leakage.labels(
                         sensor_name=sensor_name,
                         rack_name=f"keep_watching_{rack_name}",


### PR DESCRIPTION
## Summary
- streamline double-loop leakage metric handling into single loop

## Testing
- `python -m py_compile exporter_main.py`
- `pip install flake8` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a53db5cee88321be3bb48503d1f87d