### PR TITLE
Add PSU health status metrics

### DIFF
--- a/exporter_config.yaml
+++ b/exporter_config.yaml
@@ -66,7 +66,7 @@ servers:
 psus:
   - name: 'Powershelf_1'
     rack_name: 'Rack_1'
-    apiUrl: 'https://192.168.2.50/redfish/v1/Chassis/chassis/Sensors/chassis_output_power'
+    ip_address: '192.168.2.50'
 
 cdu:
   - rack_name: 'cdu1'


### PR DESCRIPTION
## Summary
- switch PSU config to ip-based addressing
- report PSU health via new Prometheus gauge

## Testing
- `python -m py_compile exporter_main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6a28115548321b9d5d92816ee4955