### PR TITLE
Set server sensor metrics to -1 on API failure

### DIFF
--- a/exporter_main.py
+++ b/exporter_main.py
@@ -206,6 +206,7 @@ def _fetch_single_server(server):
         "name": server_label,
         "sensors": {},
     }
+    thermal_sensor_names = list(sensor_gauge_map.keys())
 
     # Thermal sensor
     try:
@@ -245,6 +246,15 @@ def _fetch_single_server(server):
                     logs.append(f"[SKIP] {ip} {sensor_name}: No Value ,state: {state}")
 
     except Exception as e:
+        for sensor_name in thermal_sensor_names:
+            gauge = sensor_gauge_map.get(sensor_name)
+            if gauge:
+                gauge.labels(
+                    server_name=ip,
+                    sensor_name=sensor_name,
+                    rack_name=rack_name,
+                ).set(-1)
+            server_entry["sensors"][sensor_name] = {"value": -1, "unit": "C"}
         logs.append(f"[ERROR] {ip} Thermal API error: {e}")
 
     # Server power metrics
@@ -280,6 +290,8 @@ def _fetch_single_server(server):
                 gauge.labels(server=ip, rack_name=rack_name).set(0)
                 logs.append(f"[SKIP] {ip} {sensor} invalid value")
         except Exception as e:
+            gauge.labels(server=ip, rack_name=rack_name).set(-1)
+            server_entry["sensors"][sensor] = {"value": -1, "unit": "W"}
             logs.append(f"[ERROR] {ip} {sensor} API error: {e}")
 
     return server_label, server_entry, logs


### PR DESCRIPTION
### Motivation
- Ensure failed Redfish API calls for server sensors are represented as `-1` in Prometheus metrics and snapshot data so downstream consumers can detect collection failures.

### Description
- Add `thermal_sensor_names = list(sensor_gauge_map.keys())` and when the Thermal API call fails set all mapped thermal gauges to `-1` and write `{"value": -1, "unit": "C"}` into `server_entry["sensors"]` for each thermal sensor.
- Update server power metrics exception handling to set the corresponding power gauge to `-1` and record `{"value": -1, "unit": "W"}` in the snapshot when an individual power sensor API call fails.
- Preserve and emit error logs for each failed API call; changes are applied to `exporter_main.py`.

### Testing
- Ran `python -m py_compile exporter_main.py` which completed successfully.
- No additional automated tests were present or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5e1f34e108321a5edd37402532817)