### PR TITLE
[codex] Add server power status metric

### DIFF
--- a/exporter_main.py
+++ b/exporter_main.py
@@ -155,6 +155,11 @@ sensor_gauge_map = {
 server_power = Gauge(
     "server_power_watt", "Total power reading", ["server", "rack_name"]
 )
+server_power_status = Gauge(
+    "server_power_status",
+    "Server power state from Redfish (1: On, 0: not On, -1: API failure)",
+    ["server", "rack_name"],
+)
 server_fan_power = Gauge(
     "server_fan_power_watt", "Total fan power reading", ["server", "rack_name"]
 )
@@ -298,6 +303,27 @@ def _fetch_single_server(server):
         "name": server_label,
         "sensors": {},
     }
+
+    # Server power state is the coarse API health signal for Grafana filtering.
+    try:
+        r = session.get(
+            f"{base_url}/Systems/Self",
+            headers={"Accept": "application/json"},
+            auth=auth,
+            verify=False,
+            timeout=15,
+        )
+        r.raise_for_status()
+        data = r.json()
+        power_state = data.get("PowerState")
+        power_status = 1 if power_state == "On" else 0
+        server_power_status.labels(server=ip, rack_name=rack_name).set(power_status)
+        server_entry["power_state"] = {"value": power_state, "status": power_status}
+        logs.append(f"[OK] {ip} PowerState = {power_state}")
+    except Exception as e:
+        server_power_status.labels(server=ip, rack_name=rack_name).set(-1)
+        server_entry["power_state"] = {"value": None, "status": -1}
+        logs.append(f"[ERROR] {ip} PowerState API error: {e}")
 
     # Thermal sensor
     try:


### PR DESCRIPTION
### Motivation
PR #26 marked every server sensor as `-1` when Redfish sensor APIs failed. That makes Prometheus keep label series for sensors that do not actually exist on a server, so Grafana can continue showing stale `-1` values even after later API calls succeed.

### Description
- Add `server_power_status{server,rack_name}` as the coarse server/API status signal.
- Query `/redfish/v1/Systems/Self` and read `PowerState` for each server.
- Export `server_power_status` as `1` when `PowerState` is `On`, `0` when the API succeeds but the state is not `On`, and `-1` when the PowerState API request fails.
- Keep sensor metrics update-only based on sensors returned by Redfish, avoiding creation of synthetic sensor label series for missing hardware.

### Impact
Grafana can filter sensor panels using `server_power_status == 1` and treat `-1` as a Redfish/BMC/API reachability issue, without forcing nonexistent sensors into Prometheus.

### Validation
- Ran `python3 -m py_compile exporter_main.py` successfully.