### PR TITLE
[codex] Update collector metrics

### DIFF
--- a/Collectors/cdu.py
+++ b/Collectors/cdu.py
@@ -6,7 +6,6 @@ from prometheus_client.core import GaugeMetricFamily
 from tsre.core.logger.log import get_logger
 from src.collectors.base import BaseCollector
 from src.utils.http_client import HttpClient
-from config.globals import GLOBAL_VARS
 from config.setting import Settings
 
 logger = get_logger("exporter_logger")
@@ -60,11 +59,6 @@ class CduCollector(BaseCollector):
                 "CDU fan failure status (1: fail, 0: ok)",
                 labels=labels,
             ),
-            "cdu_calculated_metric": GaugeMetricFamily(
-                setting.metric_prefix + "cdu_calculated_metric",
-                "Calculated metrics from CDU",
-                labels=labels,
-            ),
         }
 
     async def collect_metrics(
@@ -83,11 +77,6 @@ class CduCollector(BaseCollector):
                 return
 
             state = {
-                "T_WI": 0,
-                "T_WO": 0,
-                "T_CCO": 0,
-                "T_CCI": 0,
-                "T_CR": 0,
                 "leakage_values": {
                     "Sensor_L1": 0,
                     "Sensor_L2": 0,
@@ -111,7 +100,7 @@ class CduCollector(BaseCollector):
                     continue
 
                 for label, value in entry.items():
-                    self._update_temperature_state(label, value, state)
+                    self._update_sensor_state(label, value, state)
                     self._classify_and_record_metric(
                         label, value, server, state
                     )
@@ -125,19 +114,9 @@ class CduCollector(BaseCollector):
             self.process_cdu_fan_fail(
                 server, state["fan_rpm"], state["fan_pwm"]
             )
-            self.process_cdu_calculated_metric(
-                server,
-                state["T_WI"],
-                state["T_WO"],
-                state["T_CR"],
-                state["T_CCO"],
-                state["T_CCI"],
-            )
 
-    def _update_temperature_state(self, label, value, state):
-        if label in state:
-            state[label] = value
-        elif label in state["leakage_values"]:
+    def _update_sensor_state(self, label, value, state):
+        if label in state["leakage_values"]:
             state["leakage_values"][label] = value
         elif label in state["tank_level_sensors"]:
             state["tank_level_sensors"][label] = value
@@ -211,11 +190,11 @@ class CduCollector(BaseCollector):
 
     def process_cdu_tank_level(self, server, tank_level_sensors):
         level_medium = level_low = critical_low = 0
-        if tank_level_sensors["Sensor_LEVH"] == 0:
+        if tank_level_sensors["Sensor_LEVL"] == 0:
             critical_low = 1
         elif tank_level_sensors["Sensor_LEVM"] == 0:
             level_low = 1
-        elif tank_level_sensors["Sensor_LEVL"] == 0:
+        elif tank_level_sensors["Sensor_LEVH"] == 0:
             level_medium = 1
 
         self.add_metric(
@@ -280,63 +259,4 @@ class CduCollector(BaseCollector):
                 server["location"],
                 f"Fan_{idx}",
                 fail,
-            )
-
-    # pylint: disable=R0917
-    def process_cdu_calculated_metric(
-        self, server, t_wi, t_wo, t_cr, t_cco, t_cci
-    ):
-        # Calculate additional metrics if all required values are available
-        if (
-            all(v is not None for v in (t_wi, t_wo))
-            and GLOBAL_VARS["total_psu_power"]
-        ):
-            lpm_w = (
-                (GLOBAL_VARS["total_psu_power"] / 0.97)
-                / 69.7833
-                / (t_wo - t_wi)
-            )
-            lpm_w_rounded = round(lpm_w, 2)
-            self.add_metric(
-                self.metrics_dict["cdu_calculated_metric"],
-                server["ip"],
-                server["location"],
-                "LPM_W",
-                lpm_w_rounded,
-            )
-            logger.info(
-                f"[OK] {server['location']} LPM_W = {lpm_w_rounded:.2f}"
-            )
-
-        if (
-            all(v is not None for v in (t_cr, t_cco))
-            and GLOBAL_VARS["total_psu_power"]
-        ):
-            lpm_c = GLOBAL_VARS["total_psu_power"] / 69.7833 / (t_cr - t_cco)
-            lpm_c_rounded = round(lpm_c, 2)
-            self.add_metric(
-                self.metrics_dict["cdu_calculated_metric"],
-                server["ip"],
-                server["location"],
-                "LPM_C",
-                lpm_c_rounded,
-            )
-            logger.info(
-                f"[OK] {server['location']} LPM_C = {lpm_c_rounded:.2f}"
-            )
-        else:
-            lpm_c = None
-
-        if lpm_c is not None and t_cco is not None and t_cci is not None:
-            heat_cc = lpm_c * (t_cco - t_cci) * 69.7833
-            heat_cc_rounded = round(heat_cc, 2)
-            self.add_metric(
-                self.metrics_dict["cdu_calculated_metric"],
-                server["ip"],
-                server["location"],
-                "Heat_CC",
-                heat_cc_rounded,
-            )
-            logger.info(
-                f"[OK] {server['location']} Heat_CC = {heat_cc_rounded:.2f}"
             )

--- a/Collectors/cdu.py
+++ b/Collectors/cdu.py
@@ -6,7 +6,6 @@ from prometheus_client.core import GaugeMetricFamily
 from tsre.core.logger.log import get_logger
 from src.collectors.base import BaseCollector
 from src.utils.http_client import HttpClient
-from config.globals import GLOBAL_VARS
 from config.setting import Settings
 
 logger = get_logger("exporter_logger")
@@ -60,11 +59,6 @@ class CduCollector(BaseCollector):
                 "CDU fan failure status (1: fail, 0: ok)",
                 labels=labels,
             ),
-            "cdu_calculated_metric": GaugeMetricFamily(
-                setting.metric_prefix + "cdu_calculated_metric",
-                "Calculated metrics from CDU",
-                labels=labels,
-            ),
         }
 
     async def collect_metrics(
@@ -77,11 +71,6 @@ class CduCollector(BaseCollector):
                 return
 
             state = {
-                "T_WI": 0,
-                "T_WO": 0,
-                "T_CCO": 0,
-                "T_CCI": 0,
-                "T_CR": 0,
                 "leakage_values": {
                     "Sensor_L1": 0,
                     "Sensor_L2": 0,
@@ -105,7 +94,7 @@ class CduCollector(BaseCollector):
                     continue
 
                 for label, value in entry.items():
-                    self._update_temperature_state(label, value, state)
+                    self._update_sensor_state(label, value, state)
                     self._classify_and_record_metric(
                         label, value, server, state
                     )
@@ -119,19 +108,9 @@ class CduCollector(BaseCollector):
             self.process_cdu_fan_fail(
                 server, state["fan_rpm"], state["fan_pwm"]
             )
-            self.process_cdu_calculated_metric(
-                server,
-                state["T_WI"],
-                state["T_WO"],
-                state["T_CR"],
-                state["T_CCO"],
-                state["T_CCI"],
-            )
 
-    def _update_temperature_state(self, label, value, state):
-        if label in state:
-            state[label] = value
-        elif label in state["leakage_values"]:
+    def _update_sensor_state(self, label, value, state):
+        if label in state["leakage_values"]:
             state["leakage_values"][label] = value
         elif label in state["tank_level_sensors"]:
             state["tank_level_sensors"][label] = value
@@ -205,11 +184,11 @@ class CduCollector(BaseCollector):
 
     def process_cdu_tank_level(self, server, tank_level_sensors):
         level_medium = level_low = critical_low = 0
-        if tank_level_sensors["Sensor_LEVH"] == 0:
+        if tank_level_sensors["Sensor_LEVL"] == 0:
             critical_low = 1
         elif tank_level_sensors["Sensor_LEVM"] == 0:
             level_low = 1
-        elif tank_level_sensors["Sensor_LEVL"] == 0:
+        elif tank_level_sensors["Sensor_LEVH"] == 0:
             level_medium = 1
 
         self.add_metric(
@@ -274,63 +253,4 @@ class CduCollector(BaseCollector):
                 server["location"],
                 f"Fan_{idx}",
                 fail,
-            )
-
-    # pylint: disable=R0917
-    def process_cdu_calculated_metric(
-        self, server, t_wi, t_wo, t_cr, t_cco, t_cci
-    ):
-        # Calculate additional metrics if all required values are available
-        if (
-            all(v is not None for v in (t_wi, t_wo))
-            and GLOBAL_VARS["total_psu_power"]
-        ):
-            lpm_w = (
-                (GLOBAL_VARS["total_psu_power"] / 0.97)
-                / 69.7833
-                / (t_wo - t_wi)
-            )
-            lpm_w_rounded = round(lpm_w, 2)
-            self.add_metric(
-                self.metrics_dict["cdu_calculated_metric"],
-                server["ip"],
-                server["location"],
-                "LPM_W",
-                lpm_w_rounded,
-            )
-            logger.info(
-                f"[OK] {server['location']} LPM_W = {lpm_w_rounded:.2f}"
-            )
-
-        if (
-            all(v is not None for v in (t_cr, t_cco))
-            and GLOBAL_VARS["total_psu_power"]
-        ):
-            lpm_c = GLOBAL_VARS["total_psu_power"] / 69.7833 / (t_cr - t_cco)
-            lpm_c_rounded = round(lpm_c, 2)
-            self.add_metric(
-                self.metrics_dict["cdu_calculated_metric"],
-                server["ip"],
-                server["location"],
-                "LPM_C",
-                lpm_c_rounded,
-            )
-            logger.info(
-                f"[OK] {server['location']} LPM_C = {lpm_c_rounded:.2f}"
-            )
-        else:
-            lpm_c = None
-
-        if lpm_c is not None and t_cco is not None and t_cci is not None:
-            heat_cc = lpm_c * (t_cco - t_cci) * 69.7833
-            heat_cc_rounded = round(heat_cc, 2)
-            self.add_metric(
-                self.metrics_dict["cdu_calculated_metric"],
-                server["ip"],
-                server["location"],
-                "Heat_CC",
-                heat_cc_rounded,
-            )
-            logger.info(
-                f"[OK] {server['location']} Heat_CC = {heat_cc_rounded:.2f}"
             )

--- a/Collectors/powershelf.py
+++ b/Collectors/powershelf.py
@@ -6,7 +6,6 @@ from prometheus_client.core import GaugeMetricFamily
 from tsre.core.logger.log import get_logger
 from src.collectors.base import BaseCollector
 from src.utils.http_client import HttpClient
-from config.globals import GLOBAL_VARS
 from config.setting import Settings
 
 logger = get_logger("exporter_logger")
@@ -69,7 +68,6 @@ class PowershelfCollector(BaseCollector):
             value,
             [server["name"]],
         )
-        GLOBAL_VARS["total_psu_power"] += value
 
     async def collect_psu_health(self, client, server, seq):
         # pylint: disable=C0301

--- a/Collectors/server.py
+++ b/Collectors/server.py
@@ -39,6 +39,11 @@ class ServerCollector(BaseCollector):
                 "Total power reading",
                 labels=labels,
             ),
+            "server_power_status": GaugeMetricFamily(
+                setting.metric_prefix + "server_power_status",
+                "Server power state from Redfish (1: On, 0: not On, -1: API failure)",
+                labels=labels,
+            ),
             "server_fan_power_watt": GaugeMetricFamily(
                 setting.metric_prefix + "server_fan_power_watt",
                 "Total fan power reading",
@@ -57,6 +62,11 @@ class ServerCollector(BaseCollector):
             "server_mem_power_watt": GaugeMetricFamily(
                 setting.metric_prefix + "server_mem_power_watt",
                 "Total memory power reading",
+                labels=labels,
+            ),
+            "server_chassis_location": GaugeMetricFamily(
+                setting.metric_prefix + "server_chassis_location",
+                "Chassis location reading from Redfish",
                 labels=labels,
             ),
         }
@@ -87,6 +97,7 @@ class ServerCollector(BaseCollector):
             "Pwr_CPU_Total": self.metrics_dict["server_cpu_power_watt"],
             "Pwr_GPU_Total": self.metrics_dict["server_gpu_power_watt"],
             "Pwr_Mem_Total": self.metrics_dict["server_mem_power_watt"],
+            "Chassis_Location": self.metrics_dict["server_chassis_location"],
         }
 
     async def collect_metrics(
@@ -94,20 +105,32 @@ class ServerCollector(BaseCollector):
     ):
         async with semaphore:
             try:
+                await self.collect_power_state(client, server)
                 await self.collect_thermal(client, server)
+                await self.collect_node_power(client, server)
                 await self.collect_fan_power(client, server)
                 await self.collect_cpu_power(client, server)
                 await self.collect_gpu_power(client, server)
                 await self.collect_dimm_power(client, server)
+                await self.collect_chassis_location(client, server)
             except Exception as e:
                 logger.error(f"{server['location']}: {e}")
 
-    # def collect_power_state(self, session, server):
-    #     url = f"https://{server['ip']}/redfish/v1/Systems/Self"
-    #     data = HttpClient.get(session, url, self.auth)
-    #     if not data:
-    #         return
-    # logger.info(result)
+    async def collect_power_state(self, client, server):
+        url = f"https://{server['ip']}/redfish/v1/Systems/Self"
+        data = await HttpClient.get(client, url, self.auth)
+        power_status = -1
+        if data:
+            power_state = data.get("PowerState")
+            power_status = 1 if power_state == "On" else 0
+
+        self.add_metric(
+            self.metrics_dict["server_power_status"],
+            server["ip"],
+            server["location"],
+            "PowerState",
+            power_status,
+        )
 
     async def collect_thermal(self, client, server):
         url = f"https://{server['ip']}/redfish/v1/Chassis/Self/Thermal"
@@ -143,6 +166,9 @@ class ServerCollector(BaseCollector):
 
     async def collect_dimm_power(self, client, server):
         await self.collect_power(client, server, "Pwr_Mem_Total")
+
+    async def collect_chassis_location(self, client, server):
+        await self.collect_power(client, server, "Chassis_Location")
 
     async def collect_power(self, client, server, sensor_name):
         # pylint: disable=C0301

--- a/Collectors/server.py
+++ b/Collectors/server.py
@@ -41,7 +41,7 @@ class ServerCollector(BaseCollector):
             ),
             "server_power_status": GaugeMetricFamily(
                 setting.metric_prefix + "server_power_status",
-                "Server power state from Redfish (1: On, 0: not On, -1: API failure)",
+                "Server power state (1: On, 0: not On, -1: API failure)",
                 labels=labels,
             ),
             "server_fan_power_watt": GaugeMetricFamily(


### PR DESCRIPTION
## Summary
- remove CDU calculated metric handling from the collector path
- add server power status and chassis location metrics to `ServerCollector`
- fix CDU tank level severity mapping to match `exporter_main.py`
- remove the unused powershelf total PSU power accumulation after calculated metrics were removed

## Why
The collector implementation had drifted from `exporter_main.py`: calculated CDU metrics were still present, server status/location metrics were missing, and tank level severity was reversed.

## Validation
- `python3 -m py_compile Collectors/server.py Collectors/cdu.py Collectors/powershelf.py`