### PR TITLE
Update powershelf fail status logic

### DIFF
--- a/Collectors/powershelf.py
+++ b/Collectors/powershelf.py
@@ -26,12 +26,12 @@ class PowershelfCollector(BaseCollector):
             ),
             "powershelf_psu_fail": GaugeMetricFamily(
                 setting.metric_prefix + "powershelf_psu_fail",
-                "PSU health status (0: OK, 1: Not OK)",
+                "PSU status (0: Health OK and State Enabled, 1: fail)",
                 labels=labels,
             ),
             "powershelf_chassis_fail": GaugeMetricFamily(
                 setting.metric_prefix + "powershelf_chassis_fail",
-                "PSU chassis input health status (0: OK, 1: Not OK)",
+                "PSU chassis input status (0: Health OK and State Enabled, 1: fail)",
                 labels=labels,
             ),
         }
@@ -113,6 +113,8 @@ class PowershelfCollector(BaseCollector):
         if not data:
             value = 1
         else:
-            health = data.get("Status", {}).get("Health")
-            value = 0 if health == "OK" else 1
+            status = data.get("Status", {})
+            health = status.get("Health")
+            state = status.get("State")
+            value = 0 if health == "OK" and state == "Enabled" else 1
         return value

--- a/Collectors/powershelf.py
+++ b/Collectors/powershelf.py
@@ -26,7 +26,7 @@ class PowershelfCollector(BaseCollector):
             ),
             "powershelf_psu_fail": GaugeMetricFamily(
                 setting.metric_prefix + "powershelf_psu_fail",
-                "PSU status (0: Health OK and State Enabled, 1: fail)",
+                "PSU status (0: Health OK, State Enabled, and Pout non-zero, 1: fail)",
                 labels=labels,
             ),
             "powershelf_chassis_fail": GaugeMetricFamily(
@@ -72,7 +72,7 @@ class PowershelfCollector(BaseCollector):
     async def collect_psu_health(self, client, server, seq):
         # pylint: disable=C0301
         url = f"https://{server['ip']}/redfish/v1/Chassis/chassis/Power/Oem/tsmc/PSU{seq}"
-        value = await self._collect_health(client, url)
+        value = await self._collect_health(client, url, require_pout_nonzero=True)
         self.add_metric(
             self.metrics_dict["powershelf_psu_fail"],
             server["ip"],
@@ -108,7 +108,7 @@ class PowershelfCollector(BaseCollector):
             [server["name"]],
         )
 
-    async def _collect_health(self, client, url):
+    async def _collect_health(self, client, url, require_pout_nonzero=False):
         data = await HttpClient.get(client, url, self.auth)
         if not data:
             value = 1
@@ -116,5 +116,19 @@ class PowershelfCollector(BaseCollector):
             status = data.get("Status", {})
             health = status.get("Health")
             state = status.get("State")
-            value = 0 if health == "OK" and state == "Enabled" else 1
+            pout_value = data.get("Pout", {}).get("Value")
+            pout_ok = (
+                self._is_nonzero_value(pout_value) if require_pout_nonzero else True
+            )
+            value = 0 if health == "OK" and state == "Enabled" and pout_ok else 1
         return value
+
+    @staticmethod
+    def _is_nonzero_value(value):
+        if value is None:
+            return False
+
+        try:
+            return float(value) != 0
+        except (TypeError, ValueError):
+            return False

--- a/exporter_main.py
+++ b/exporter_main.py
@@ -184,7 +184,7 @@ psu_power_output = Gauge(
 )
 powershelf_psu_fail = Gauge(
     "powershelf_psu_fail",
-    "PSU status (0: Health OK and State Enabled, 1: fail)",
+    "PSU status (0: Health OK, State Enabled, and Pout non-zero, 1: fail)",
     ["sensor_name", "rack_name"],
 )
 powershelf_chassis_fail = Gauge(
@@ -270,6 +270,16 @@ def _get_session():
         session = requests.Session()
         _thread_local.session = session
     return session
+
+
+def _is_nonzero_value(value):
+    if value is None:
+        return False
+
+    try:
+        return float(value) != 0
+    except (TypeError, ValueError):
+        return False
 
 
 def _get_server_executor():
@@ -578,17 +588,31 @@ def fetch_psu_data():
                 status = status_data.get('Status', {})
                 health = status.get('Health')
                 state = status.get('State')
-                metric_value = 0 if health == "OK" and state == "Enabled" else 1
+                pout_value = status_data.get("Pout", {}).get("Value")
+                metric_value = (
+                    0
+                    if health == "OK"
+                    and state == "Enabled"
+                    and _is_nonzero_value(pout_value)
+                    else 1
+                )
                 psu_entry[f"PSU_{i}_Health"] = {"value": health, "unit": None}
                 psu_entry[f"PSU_{i}_State"] = {"value": state, "unit": None}
+                psu_entry[f"PSU_{i}_Pout"] = {"value": pout_value, "unit": None}
                 powershelf_psu_fail.labels(
                     sensor_name=f"PSU_{i}",
                     rack_name=rack_name,
                 ).set(metric_value)
                 if metric_value == 0:
-                    print(f"[OK] {psu['name']} PSU_{i} Health {health} State {state}")
+                    print(
+                        f"[OK] {psu['name']} PSU_{i} "
+                        f"Health {health} State {state} Pout {pout_value}"
+                    )
                 else:
-                    print(f"[WARN] {psu['name']} PSU_{i} Health {health} State {state}")
+                    print(
+                        f"[WARN] {psu['name']} PSU_{i} "
+                        f"Health {health} State {state} Pout {pout_value}"
+                    )
                 status_failures[sensor_key] = 0
             except Exception as e:
                 failure_count = status_failures.get(sensor_key, 0) + 1

--- a/exporter_main.py
+++ b/exporter_main.py
@@ -184,12 +184,12 @@ psu_power_output = Gauge(
 )
 powershelf_psu_fail = Gauge(
     "powershelf_psu_fail",
-    "PSU health status (0: OK, 1: Not OK)",
+    "PSU status (0: Health OK and State Enabled, 1: fail)",
     ["sensor_name", "rack_name"],
 )
 powershelf_chassis_fail = Gauge(
     "powershelf_chassis_fail",
-    "PSU chassis input health status (0: OK, 1: Not OK)",
+    "PSU chassis input status (0: Health OK and State Enabled, 1: fail)",
     ["sensor_name", "rack_name"],
 )
 cdu_temperature = Gauge(
@@ -575,17 +575,20 @@ def fetch_psu_data():
                     timeout=10,
                 )
                 status_data = status_resp.json()
-                health = status_data.get('Status', {}).get('Health')
-                metric_value = 0 if health == "OK" else 1
+                status = status_data.get('Status', {})
+                health = status.get('Health')
+                state = status.get('State')
+                metric_value = 0 if health == "OK" and state == "Enabled" else 1
                 psu_entry[f"PSU_{i}_Health"] = {"value": health, "unit": None}
+                psu_entry[f"PSU_{i}_State"] = {"value": state, "unit": None}
                 powershelf_psu_fail.labels(
                     sensor_name=f"PSU_{i}",
                     rack_name=rack_name,
                 ).set(metric_value)
-                if health == "OK":
-                    print(f"[OK] {psu['name']} PSU_{i} Health {health}")
+                if metric_value == 0:
+                    print(f"[OK] {psu['name']} PSU_{i} Health {health} State {state}")
                 else:
-                    print(f"[WARN] {psu['name']} PSU_{i} Health {health}")
+                    print(f"[WARN] {psu['name']} PSU_{i} Health {health} State {state}")
                 status_failures[sensor_key] = 0
             except Exception as e:
                 failure_count = status_failures.get(sensor_key, 0) + 1
@@ -617,18 +620,21 @@ def fetch_psu_data():
                     timeout=10,
                 )
                 chassis_data = chassis_resp.json()
-                health = chassis_data.get("Status", {}).get("Health")
-                metric_value = 0 if health == "OK" else 1
+                status = chassis_data.get("Status", {})
+                health = status.get("Health")
+                state = status.get("State")
+                metric_value = 0 if health == "OK" and state == "Enabled" else 1
                 psu_entry[f"{chassis_label}_Health"] = {"value": health, "unit": None}
+                psu_entry[f"{chassis_label}_State"] = {"value": state, "unit": None}
                 powershelf_chassis_fail.labels(
                     sensor_name=chassis_label,
                     rack_name=rack_name,
                 ).set(metric_value)
                 status_failures[sensor_key] = 0
-                if health == "OK":
-                    print(f"[OK] {psu['name']} {chassis_label} Health {health}")
+                if metric_value == 0:
+                    print(f"[OK] {psu['name']} {chassis_label} Health {health} State {state}")
                 else:
-                    print(f"[WARN] {psu['name']} {chassis_label} Health {health}")
+                    print(f"[WARN] {psu['name']} {chassis_label} Health {health} State {state}")
             except Exception as e:
                 failure_count = status_failures.get(sensor_key, 0) + 1
                 status_failures[sensor_key] = failure_count


### PR DESCRIPTION
## Summary
- Update powershelf PSU fail logic to require `Status.Health == "OK"`, `Status.State == "Enabled"`, and `Pout.Value != 0` before setting metric value to `0`
- Apply the Health/State logic to powershelf chassis fail metrics
- Include State/Pout in exporter status records and logs, and update metric descriptions

## Test
- `python3 -m py_compile Collectors/powershelf.py exporter_main.py`